### PR TITLE
add Supervisor url to open manually in a browser tab

### DIFF
--- a/content/en/docs/Tutorials/Getting started/_index.md
+++ b/content/en/docs/Tutorials/Getting started/_index.md
@@ -40,3 +40,5 @@ When you click on a robot in the simulation window, red, blue, and green arrows 
 1. If the Scene Tree is not displayed, go to Tools --> Scene Tree in the top menu to display it.
 2. Find "DEF MAINSUPERVISOR Robot" in the Scene Tree and right-click it. Click on "Show Robot Window".
 {{< figure src="showrobot.png" class="center" width="400">}}
+
+3. If the Supervisor tab still does not open, try to open the following [link](http://localhost:1234/robot_windows/MainSupervisorWindow/MainSupervisorWindow.html?name=robot) in your browser manually.


### PR DESCRIPTION
On linux, the "Show Robot Window" button does not work on some Desktop Environments.
This adds a link to the localhost address the supervisor is accessible on to open manually if required.